### PR TITLE
Point setup review at generic Stripe account

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Setting up Plaid, Coinbase OAuth, Prisma, and optional SES notifications can inv
 
 If you want a second pass on your setup, you can buy a `$12` manual setup review:
 
-[Buy the setup review](https://buy.stripe.com/8x27sNaZP691dWKbjU8so07)
+[Buy the setup review](https://buy.stripe.com/9B614m8vxeZi80z63vaMU06)
 
 The review covers environment variables, redirect URI alignment, database setup, local run steps, and email notification readiness. It is not financial advice, tax advice, investment advice, or account troubleshooting. Do not send bank credentials, Coinbase credentials, Plaid secrets, account balances, transaction exports, database files, screenshots with private financial data, or production tokens.
 

--- a/docs/setup-readiness-checklist.md
+++ b/docs/setup-readiness-checklist.md
@@ -42,6 +42,6 @@ Use this checklist before connecting real accounts or moving beyond a local deve
 
 If you want a manual setup review, use the `$12` checkout link:
 
-https://buy.stripe.com/8x27sNaZP691dWKbjU8so07
+https://buy.stripe.com/9B614m8vxeZi80z63vaMU06
 
 Include only sanitized setup context such as your repo URL, deploy URL, environment names, error messages with secrets removed, or a short description of the blocker. Do not send private financial records or credentials.


### PR DESCRIPTION
## Summary\n- Replace the Personal Finance Dashboard setup review checkout URL with the shared generic Stripe account Payment Link.\n\n## Verification\n- git diff --check\n- npx --yes prettier@3.3.3 --check README.md docs/setup-readiness-checklist.md\n- Stripe retrieve verified the new link is active/livemode at  with the expected redirect and custom fields.